### PR TITLE
Feat: pull pubkey from server on compatibility tester

### DIFF
--- a/extension/chrome/settings/modules/compatibility.htm
+++ b/extension/chrome/settings/modules/compatibility.htm
@@ -20,6 +20,11 @@
     <div class="line">Locally test any public or private key.</div>
 
     <div class="line">
+      <input placeholder="Enter KeyID or Email address" class="input_keyid_or_email" />
+      <button class="button green action_load_public_key">load public key</button>
+    </div>
+
+    <div class="line">
       <textarea placeholder="ASCII Armored Public or Private Key....." class="input_key" style="width: 650px; height: 200px;" spellcheck="false" maxlength="80000"></textarea>
     </div>
 

--- a/extension/chrome/settings/modules/compatibility.htm
+++ b/extension/chrome/settings/modules/compatibility.htm
@@ -20,7 +20,7 @@
     <div class="line">Locally test any public or private key.</div>
 
     <div class="line">
-      <input placeholder="Enter KeyID or Email address" class="input_keyid_or_email" />
+      <input type="text" placeholder="Enter KeyID or Email address" class="input_keyid_or_email" />
       <button class="button green action_load_public_key">load public key</button>
     </div>
 

--- a/extension/chrome/settings/modules/compatibility.ts
+++ b/extension/chrome/settings/modules/compatibility.ts
@@ -7,6 +7,7 @@ import { Ui } from '../../../js/common/browser/ui.js';
 import { View } from '../../../js/common/view.js';
 import { Xss } from '../../../js/common/platform/xss.js';
 import { KeyUtil, Key } from '../../../js/common/core/crypto/key.js';
+import { Api } from '../../../js/common/api/shared/api.js';
 
 View.run(
   class CompatibilityView extends View {
@@ -22,6 +23,7 @@ View.run(
 
     public setHandlers = () => {
       $('.action_test_key').on('click', this.setHandlerPrevent('double', this.actionTestKeyHandler));
+      $('.action_load_public_key').on('click', this.setHandlerPrevent('double', this.actionLoadPublicKey))
       $('#input_passphrase').keydown(this.setEnterHandlerThatClicks('.action_test_key'));
     };
 
@@ -54,6 +56,13 @@ View.run(
           this.appendResult(`${kn} ${entry[0]}: ${entry[1]}`);
         }
       }
+    };
+
+    private actionLoadPublicKey = async () => {
+      const keyid_or_email = String($('.input_keyid_or_email').val());
+      const buf = await Api.download(`https://flowcrypt.com/attester/pub/${keyid_or_email}`);
+      const publicKey = buf.toUtfStr();
+      $('.input_key').val(publicKey);
     };
 
     private actionTestKeyHandler = async (submitBtn: HTMLElement) => {


### PR DESCRIPTION
This PR adds a feature to pull a public key from the server on the compatibility tester page.

Screenshot:

![image](https://user-images.githubusercontent.com/46025304/232199345-1433198d-243b-4594-a93e-e6575f5f3092.png)
